### PR TITLE
Add optional refund amount to payment contract

### DIFF
--- a/src/Apility/Payment/Concerns/CreatesNetsEasyPayments.php
+++ b/src/Apility/Payment/Concerns/CreatesNetsEasyPayments.php
@@ -76,10 +76,10 @@ trait CreatesNetsEasyPayments
         return null;
     }
 
-    protected function createNetsEasyOrderPayload(Order $order, array $options = []): array
+    protected function createNetsEasyCartItem(CartItem $item)
     {
-        $items = array_map(fn (CartItem $item) => [
-            'reference' => $item->getCartItemProductId(),
+        return [
+            'reference' => (string)$item->getCartItemLineNumber(),
             'name' => $this->getNetsEasyCartItemName($item),
             'quantity' => $item->getCartItemQuantity(),
             'unit' => 'x',
@@ -88,7 +88,12 @@ trait CreatesNetsEasyPayments
             'taxAmount' => (int)number_format(floatval($item->getCartItemTax()), 2, '', ''), // The total tax amount for this item in cents,
             'grossTotalAmount' => (int)number_format(floatval($item->getCartItemTotal()), 2, '', ''), // Total for this item with tax in cents,
             'netTotalAmount' => (int)number_format(floatval($item->getCartItemSubtotal()), 2, '', ''), // Total for this item without tax in cents
-        ], $order->getOrderCartItems());
+        ];
+    }
+
+    protected function createNetsEasyOrderPayload(Order $order, array $options = []): array
+    {
+        $items = array_map(fn(CartItem $item) => $this->createNetsEasyCartItem($item), $order->getOrderCartItems());
 
         if ($order->checkout->shipping_total > 0) {
             $items[] = [

--- a/src/Apility/Payment/Contracts/Payment.php
+++ b/src/Apility/Payment/Contracts/Payment.php
@@ -16,7 +16,20 @@ interface Payment extends OrderPayment, Responsable
 
     public function cancel(): bool;
 
-    public function refund(): bool;
+    /**
+     *
+     * Refund payment partially or fully.
+     *
+     * Amount must be supplied in the same format as getChargedAmount/getTotalAmount.
+     * In other words, dont use cents, use the main currency unit(NOK, USD), not the fractional currency unit(Øre, Cents)
+     *
+     * @see self::getChargedAmount
+     * @see self::getTotalAmount
+     *
+     * @param float|null $amount
+     * @return bool
+     */
+    public function refund(?float $amount = null): bool;
 
     public function paid(): bool;
 

--- a/src/Apility/Payment/Payments/NetsEasyPayment.php
+++ b/src/Apility/Payment/Payments/NetsEasyPayment.php
@@ -5,6 +5,7 @@ namespace Apility\Payment\Payments;
 use Apility\Payment\Processors\NetsEasy;
 use DateTimeInterface;
 
+use Netflex\Commerce\CartItem;
 use Netflex\Commerce\Contracts\Order;
 
 use Nets\Easy\Payment as EasyPayment;
@@ -74,10 +75,34 @@ class NetsEasyPayment extends AbstractPayment
         }
     }
 
-    public function refund(): bool
+    public function refund(?float $amount = null): bool
     {
+
+        if(!$amount) {
+            $options = [
+                'amount' => $this->getChargedAmount() * 100
+            ];
+
+        } else {
+            $options = [
+                'amount' => $amount * 100,
+                'orderItems' => [
+                    $this->createNetsEasyCartItem(new CartItem([
+                        'id' => '-1',
+                        'entry_name' => 'Refund',
+                        'variant_name' => 'sum',
+                        'no_of_entries' => 1,
+                        'entry_cost' => $amount,
+                        'tax_percent' => 1.0,
+                        'entries_cost' => $amount,
+                        'entries_total' => $amount,
+                    ])),
+                ]
+            ];
+        }
+
         foreach ($this->payment->charges as $charge) {
-            if ($this->payment->refund($charge['chargeId'], ['amount' => $this->getChargedAmount() * 100])) {
+            if ($this->payment->refund($charge['chargeId'], $options)) {
                 return true;
             }
         }

--- a/src/Apility/Payment/Payments/NullPayment.php
+++ b/src/Apility/Payment/Payments/NullPayment.php
@@ -45,7 +45,7 @@ class NullPayment extends AbstractPayment
         return true;
     }
 
-    public function refund(): bool
+    public function refund(?float $amount = null): bool
     {
         return true;
     }


### PR DESCRIPTION
Expects only a single charged payment on the object.
This will have to be redone when we support multiple charges better.
